### PR TITLE
CanUseAction: Add level check of playerlevel < action level

### DIFF
--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -215,6 +215,7 @@ namespace MOAction
             MoActionStack stackToUse = null;
             foreach (var entry in applicableActions)
             {
+                pluginLog.Verbose("{stackname} for job {job}",entry.BaseAction.Name,entry.Job.);
                 if (entry.Modifier == VirtualKey.NO_KEY)
                 {
                     stackToUse = entry;
@@ -293,12 +294,18 @@ namespace MOAction
                 else if (err != 0 && err != 565) return false;
             }
 
-            pluginLog.Debug("is {actionName} usable at level: {level} available for player {playername} with {playerlevel}?",action.Name, action.ClassJobLevel,player.Name,player.Level);
-            if(action.ClassJobLevel > clientState.LocalPlayer.Level) return false;
+            //Skip actions you cannot use when synced down, excluding role actions that can be used even when syncing down.
+            pluginLog.Verbose("is {actionname} a role action?: {answer}",action.Name, action.IsRoleAction);
+            if(!action.IsRoleAction){
+                pluginLog.Verbose("is {actionName} usable at level: {level} available for player {playername} with {playerlevel}?",action.Name, action.ClassJobLevel,player.Name,player.Level);
+                if(!action.IsRoleAction && action.ClassJobLevel > clientState.LocalPlayer.Level) return false;
+            }
             
+            //area of effect spells do not require a target to work.
             pluginLog.Verbose("is {actionname} a area spell/ability? {answer}", action.Name, action.TargetArea);
             if(action.TargetArea) return true;
 
+            //handoff to game native code, returns true if the actionManager declares that the action can be used on the target specified
             pluginLog.Verbose("can I use action: {rowid} with name {actionname} on target {targetid} with name {targetname}", action.RowId.ToString(), action.Name, target.DataId, target.Name);
             return ActionManager.CanUseActionOnTarget(action.RowId,target_ptr);
         }

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -297,7 +297,7 @@ namespace MOAction
             pluginLog.Verbose("is {actionname} a role action?: {answer}",action.Name, action.IsRoleAction);
             if(!action.IsRoleAction){
                 pluginLog.Verbose("is {actionName} usable at level: {level} available for player {playername} with {playerlevel}?",action.Name, action.ClassJobLevel,player.Name,player.Level);
-                if(!action.IsRoleAction && action.ClassJobLevel > clientState.LocalPlayer.Level) return false;
+                if(action.ClassJobLevel > clientState.LocalPlayer.Level) return false;
             }
             
             //area of effect spells do not require a target to work.

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -281,10 +281,11 @@ namespace MOAction
                 }
             }
 
+            var player = clientState.LocalPlayer;
             var target_ptr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)target.Address;
             if (Configuration.RangeCheck)
             { 
-                var player = clientState.LocalPlayer;
+                
                 var player_ptr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)player.Address;
 
                 uint err = ActionManager.GetActionInRangeOrLoS(action.RowId, player_ptr, target_ptr);
@@ -292,6 +293,9 @@ namespace MOAction
                 else if (err != 0 && err != 565) return false;
             }
 
+            pluginLog.Debug("is {actionName} usable at level: {level} available for player {playername} with {playerlevel}?",action.Name, action.ClassJobLevel,player.Name,player.Level);
+            if(action.ClassJobLevel > clientState.LocalPlayer.Level) return false;
+            
             pluginLog.Verbose("is {actionname} a area spell/ability? {answer}", action.Name, action.TargetArea);
             if(action.TargetArea) return true;
 

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -215,7 +215,6 @@ namespace MOAction
             MoActionStack stackToUse = null;
             foreach (var entry in applicableActions)
             {
-                pluginLog.Verbose("{stackname} for job {job}",entry.BaseAction.Name,entry.Job.);
                 if (entry.Modifier == VirtualKey.NO_KEY)
                 {
                     stackToUse = entry;


### PR DESCRIPTION
this would return no if your stack tries to use Cure 2 when inside synced Satasha on a white mage, preventing a pop-up of: "action not yet learned".

this would also allow a stack of:

Target Cure 2
Target Cure 1

and cast cure 1 when synced below the level of cure 2